### PR TITLE
Fix to handle Airly API rate limit limitations 

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2,7 +2,11 @@ GIOS_FIND_ALL_STATION_URL = 'http://api.gios.gov.pl/pjp-api/rest/station/findAll
 GIOS_GET_SENSORS_IN_STATION_URL = 'http://api.gios.gov.pl/pjp-api/rest/station/sensors/'
 GIOS_GET_SENSOR_STATUS_URL = 'http://api.gios.gov.pl/pjp-api/rest/data/getData/'
 
-AIRLY_TOKEN = '1dec2a6997cb4daea383808818f6d4e9'
+# Old key that can be used again if needed
+#AIRLY_TOKEN = '1dec2a6997cb4daea383808818f6d4e9'
+
+AIRLY_TOKEN = 'cbac83d0d9df4500bb7e551ce8133e3b'
+
 AIRLY_FIND_ALL_STATION_URL = 'https://airapi.airly.eu/v1/sensors/current?southwestLat=50&southwestLong=19.9&northeastLat=50.09&northeastLong=20.02'
 AIRLY_GET_STATION_STATUS_URL = 'https://airapi.airly.eu/v1/sensor/measurements?sensorId='
 

--- a/api/monitoring/airly.py
+++ b/api/monitoring/airly.py
@@ -1,4 +1,4 @@
-import requests
+import requests, time
 from api import config, producer
 from datetime import datetime
 
@@ -19,11 +19,12 @@ for station in resonse:
         normalized_measurements = {}
         normalized_measurements['id'] = station['id']
         normalized_measurements['vendor'] = 'AIRLY'
-
+        
         normalized_measurements['pm2_5'] = measurements['pm25'] if 'pm25' in measurements else None
         normalized_measurements['pm10'] = measurements['pm10'] if 'pm10' in measurements else None
         normalized_measurements['temperature'] = measurements['temperature'] if 'temperature' in measurements else None
         normalized_measurements['date'] = datetime.strptime(status['fromDateTime'], '%Y-%m-%dT%H:%M:%SZ').strftime("%Y-%m-%d %H:%M:%S")
-
+        
         producer.send('monitoring', normalized_measurements)
         print("Send info about station {}".format(station['id']))
+        time.sleep(2)

--- a/api/station/airly.py
+++ b/api/station/airly.py
@@ -1,4 +1,4 @@
-import requests
+import requests, time
 from api import config, producer
 
 headers = {
@@ -23,6 +23,7 @@ for station in resonse:
 
     producer.send('station', normalized_station)
     print("Send info about station {}".format(normalized_station['id']))
+    time.sleep(2)
 
 
 


### PR DESCRIPTION
Airly must be changed to avoid 'API rate limit' error message because they limits frequency of querying their services.